### PR TITLE
set path on cookie when reauthorizing

### DIFF
--- a/lib/routes/auth/reauthorize.js
+++ b/lib/routes/auth/reauthorize.js
@@ -25,7 +25,8 @@ module.exports = [{
                 h.state('_pallies', results.refreshToken, {
                     ttl: refreshTokenLifespan * 1000,
                     isSecure: !isDev,
-                    isHttpOnly: true
+                    isHttpOnly: true,
+                    path: '/reauthorize'
                 });
             }
 


### PR DESCRIPTION
Found while working on https://github.com/BigRoomStudios/strangeluv/pull/288.  This caused the second reauthorization attempt to fail, as we'd have two pallies cookies

![Screen Shot 2023-02-09 at 9 15 45 AM](https://user-images.githubusercontent.com/1681859/217847532-a9ac9041-9f73-4d17-a1c9-288757c50658.png)
