### PR TITLE
Centralize pallies cookie mgmt

### DIFF
--- a/lib/cookies/pallies.js
+++ b/lib/cookies/pallies.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = (server, { isDev, refreshToken = {} }) => ({
+    name: refreshToken.name ?? '_pallies',
+    options: {
+        ttl: refreshToken.lifespan * 1000,
+        isSecure: !isDev,
+        isHttpOnly: true,
+        path: refreshToken.path ?? '/reauthorize'
+    }
+});

--- a/lib/models/refreshToken.js
+++ b/lib/models/refreshToken.js
@@ -57,7 +57,7 @@ class RefreshToken extends Model {
 
         const now = new Date();
 
-        this.expiredAt = this.expiredAt || new Date(now.getTime() + Config.jwt.refreshTokenLifespan * 1000);
+        this.expiredAt = this.expiredAt || new Date(now.getTime() + Config.refreshToken.lifespan * 1000);
     }
 }
 

--- a/lib/routes/auth/login.js
+++ b/lib/routes/auth/login.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Joi = require('joi');
-const Toys = require('toys');
 
 module.exports = {
     method: 'POST',
@@ -17,17 +16,11 @@ module.exports = {
 
             const { authService, tokenService } = h.services();
             const { username, password } = request.payload;
-            const { isDev, jwt: { refreshTokenLifespan } } = Toys.options(request);
 
             const results = await authService.login(username, password);
 
             if (!results.isBoom) {
-                h.state('_pallies', results.refreshToken, {
-                    ttl: refreshTokenLifespan * 1000,
-                    isSecure: !isDev,
-                    isHttpOnly: true,
-                    path: '/reauthorize'
-                });
+                h.state('_pallies', results.refreshToken);
             }
 
             return tokenService.present(results);

--- a/lib/routes/auth/reauthorize.js
+++ b/lib/routes/auth/reauthorize.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const Boom = require('@hapi/boom');
-const Toys = require('toys');
 const RefreshToken = require('../../models/refreshToken');
 
 module.exports = [{
@@ -12,7 +11,6 @@ module.exports = [{
         handler: async (request, h) => {
 
             const { authService, tokenService } = h.services();
-            const { isDev, jwt: { refreshTokenLifespan } } = Toys.options(request);
             const { _pallies } = request.state;
 
             if (!_pallies) {
@@ -22,12 +20,7 @@ module.exports = [{
             const results = await authService.reauthorize(_pallies);
 
             if (!results.isBoom) {
-                h.state('_pallies', results.refreshToken, {
-                    ttl: refreshTokenLifespan * 1000,
-                    isSecure: !isDev,
-                    isHttpOnly: true,
-                    path: '/reauthorize'
-                });
+                h.state('_pallies', results.refreshToken);
             }
 
             return tokenService.present(results);

--- a/server/.palliesrc.js
+++ b/server/.palliesrc.js
@@ -20,10 +20,11 @@ module.exports = {
         development: true
     },
     jwt: {
-        useRefreshTokens: true,
         issuer: 'Pallies',
-        accessTokenLifespan: 3600,
-        refreshTokenLifespan: 604800
+        accessTokenLifespan: 3600
+    },
+    refreshToken: {
+        lifespan: 604800
     },
     application: {
         name: 'Pallies',


### PR DESCRIPTION
Moves inline cookie settings to single call to `server.state()` plus allows overwriting settings